### PR TITLE
Revised Norwegian (nb) translations (#6525)

### DIFF
--- a/lib/language.js
+++ b/lib/language.js
@@ -526,7 +526,7 @@ function init() {
       ,ja: '今日'
       ,dk: 'I dag'
       ,fi: 'Tänään'
-      ,nb: 'Idag'
+      ,nb: 'I dag'
       ,he: 'היום'
       ,pl: 'Dziś'
       ,ru: 'Сегодня'
@@ -708,7 +708,7 @@ function init() {
       ,ja: 'between'
       ,dk: 'between'
       ,fi: 'between'
-      ,nb: 'between'
+      ,nb: 'mellom'
       ,he: 'between'
       ,pl: 'between'
       ,ru: 'между'
@@ -734,7 +734,7 @@ function init() {
       ,ja: 'around'
       ,dk: 'around'
       ,fi: 'around'
-      ,nb: 'around'
+      ,nb: 'rundt'
       ,he: 'around'
       ,pl: 'around'
       ,ru: 'около'
@@ -760,7 +760,7 @@ function init() {
       ,ja: 'and'
       ,dk: 'and'
       ,fi: 'and'
-      ,nb: 'and'
+      ,nb: 'og'
       ,he: 'and'
       ,pl: 'and'
       ,ru: 'и'
@@ -1359,7 +1359,7 @@ function init() {
       ,ja: 'データなし'
       ,dk: 'Ingen'
       ,fi: 'tyhjä'
-      ,nb: 'ingen'
+      ,nb: 'Ingen'
       ,he: 'ללא'
       ,pl: 'brak'
       ,ru: 'Нет'
@@ -1463,7 +1463,7 @@ function init() {
       ,it: 'Week to week'
       ,dk: 'Week to week'
       ,fi: 'Week to week'
-      ,nb: 'Week to week'
+      ,nb: 'Uke for uke'
       ,he: 'Week to week'
       ,pl: 'Tydzień po tygodniu'
       ,ru: 'По неделям'
@@ -1514,7 +1514,7 @@ function init() {
       ,ja: 'パーセント図'
       ,dk: 'Procentgraf'
       ,fi: 'Suhteellinen kuvaaja'
-      ,nb: 'Prosentgraf'
+      ,nb: 'Persentildiagram'
       ,he: 'טבלת עשירונים'
       ,pl: 'Wykres percentyl'
       ,ru: 'Процентильная диаграмма'
@@ -1584,6 +1584,7 @@ function init() {
       ,he: 'netIOB סטטיסטיקת'
       ,de: 'netIOB Statistiken'
       ,fi: 'netIOB tilasto'
+      ,nb: 'netIOB statistikk'
       ,bg: 'netIOB татистика'
       ,hr: 'netIOB statistika'
       , pl: 'Statystyki netIOP'
@@ -1596,6 +1597,7 @@ function init() {
       ,sv: 'temp basal måste vara synlig för denna rapport'
       ,de: 'temporäre Basalraten müssen für diesen Report sichtbar sein'
       ,fi: 'tämä raportti vaatii, että basaalien piirto on päällä'
+      ,nb: 'midlertidig basal må være synlig for å vise denne rapporten'
       ,bg: 'временните базали трябва да са показани за да се покаже тази това'
       ,hr: 'temp bazali moraju biti prikazani kako bi se vidio ovaj izvještaj'
       ,he: 'חובה לאפשר רמה בזלית זמנית כדי לרות דוח זה'
@@ -2035,7 +2037,7 @@ function init() {
       ,ja: 'グルコース(%)レポート'
       ,dk: 'Glukoserapport i procent'
       ,fi: 'Verensokeriarvojen jakauma'
-      ,nb: 'Glukoserapport i prosent'
+      ,nb: 'Persentildiagram for blodsukker'
       ,he: 'דוח אחוזון סוכר'
       ,pl: 'Tabela centylowa glikemii'
       ,ru: 'Процентильная ГК'
@@ -2087,7 +2089,7 @@ function init() {
       ,ja: '合計日数'
       ,dk: 'antal dage'
       ,fi: 'päivän arvio'
-      ,nb: 'antall dager'
+      ,nb: 'dager'
       ,he: 'מספר ימים'
       ,pl: 'dni łącznie'
       ,ru: 'всего дней'
@@ -2112,7 +2114,7 @@ function init() {
       ,it: 'Giorni totali'
       ,dk: 'antal dage'
       ,fi: 'päivän arvio'
-      ,nb: 'antall dager'
+      ,nb: 'Totalt per dag'
       ,he: 'מספר ימים'
       ,pl: 'dni łącznie'
       ,ru: 'всего за сутки'
@@ -2138,7 +2140,7 @@ function init() {
       ,ja: '総合'
       ,dk: 'Gennemsnit'
       ,fi: 'Yhteenveto'
-      ,nb: 'Generelt'
+      ,nb: 'Totalt'
       ,he: 'סך הכל'
       ,pl: 'Ogółem'
       ,ru: 'Суммарно'
@@ -2190,7 +2192,7 @@ function init() {
       ,ja: '%精度'
       ,dk: '% af aflæsningerne'
       ,fi: '% lukemista'
-      ,nb: '% af avlesningene'
+      ,nb: '% av avlesningene'
       ,he: 'אחוז קריאות'
       ,pl: '% Odczytów'
       ,ru: '% измерений'
@@ -2294,7 +2296,7 @@ function init() {
       ,ja: '最大値'
       ,dk: 'Max'
       ,fi: 'Maks'
-      ,nb: 'Max'
+      ,nb: 'Maks'
       ,he: 'מקסימאלי'
       ,pl: 'Max'
       ,ru: 'Макс'
@@ -2426,7 +2428,7 @@ function init() {
       ,ja: '保存されたAPI secret hashを使用する'
       ,dk: 'Anvender gemt API-nøgle'
       ,fi: 'Tallennettu salainen API-tarkiste käytössä'
-      ,nb: 'Bruker lagret API nøkkel'
+      ,nb: 'Bruker lagret API-nøkkel'
       ,pl: 'Korzystając z zapisanego poufnego hasha API'
       ,ru: 'Применение сохраненного пароля API'
       ,sk: 'Používam uložený API hash heslo'
@@ -2452,7 +2454,7 @@ function init() {
       ,ja: 'API secret hashがまだ保存されていません。API secretの入力が必要です。'
       ,dk: 'Mangler API-nøgle. Du skal indtaste API nøglen'
       ,fi: 'Salainen API-tarkiste puuttuu. Syötä API tarkiste.'
-      ,nb: 'Mangler API nøkkel. Du må skrive inn API hemmelighet.'
+      ,nb: 'Mangler API-nøkkel. Du må skrive inn API-hemmelighet.'
       ,he:'הכנס את הסיסמא הסודית של ה API'
       ,pl: 'Nie ma żadnego poufnego hasha API zapisanego. Należy wprowadzić poufny hash API.'
       ,ru: 'Пароля API нет в памяти. Введите пароль API'
@@ -2505,7 +2507,7 @@ function init() {
       ,ja: 'エラー：データベースを読み込めません'
       ,dk: 'Fejl: Database kan ikke indlæses'
       ,fi: 'Virhe: Tietokannan lataaminen epäonnistui'
-      ,nb: 'Feil: Database kan ikke leses'
+      ,nb: 'Feil: Database kunne ikke leses'
       ,he: 'שגיאה: לא ניתן לטעון בסיס נתונים'
       ,pl: 'Błąd, baza danych nie może być załadowana'
       ,ru: 'Ошибка: Не удалось загрузить базу данных'
@@ -2519,7 +2521,7 @@ function init() {
     ,'Error' : {
       cs: 'Error'
       ,he: 'Error'
-      ,nb: 'Error'
+      ,nb: 'Feil'
       ,fr: 'Error'
       ,ro: 'Error'
       ,el: 'Error'
@@ -2557,7 +2559,7 @@ function init() {
       ,ja: '新しい記録を作る'
       ,dk: 'Opret ny post'
       ,fi: 'Luo uusi tallenne'
-      ,nb: 'Lager ny registrering'
+      ,nb: 'Opprette ny registrering'
       ,he: 'צור רשומה חדשה'
       ,pl: 'Tworzenie nowego wpisu'
       ,ru: 'Создайте новую запись'
@@ -2583,7 +2585,7 @@ function init() {
       ,ja: '保存'
       ,dk: 'Gemmer post'
       ,fi: 'Tallenna'
-      ,nb: 'Lagrer registrering'
+      ,nb: 'Lagre registrering'
       ,he: 'שמור רשומה'
       ,pl: 'Zapisz wpis'
       ,ru: 'Сохраните запись'
@@ -2818,7 +2820,7 @@ function init() {
       ,ja: 'APIシークレットは12文字以上の長さが必要です'
       ,dk: 'Din API nøgle skal være mindst 12 tegn lang'
       ,fi: 'API-avaimen tulee olla ainakin 12 merkin mittainen'
-      ,nb: 'Din API nøkkel må være minst 12 tegn lang'
+      ,nb: 'Din API-nøkkel må være minst 12 tegn lang'
       ,pl: 'Twój poufny klucz API musi zawierać co majmniej 12 znaków'
       ,ru: 'Ваш пароль API должен иметь не менее 12 знаков'
       ,sk: 'Vaše API heslo musí mať najmenej 12 znakov'
@@ -2845,7 +2847,7 @@ function init() {
       ,ja: 'APIシークレットは正しくありません'
       ,dk: 'Forkert API-nøgle'
       ,fi: 'Väärä API-avain'
-      ,nb: 'Ugyldig API nøkkel'
+      ,nb: 'Ugyldig API-nøkkel'
       ,pl: 'Błędny klucz API'
       ,ru: 'Плохой пароль API'
       ,sk: 'Nesprávne API heslo'
@@ -2872,7 +2874,7 @@ function init() {
       ,ja: 'APIシークレットを保存出来ました'
       ,dk: 'Hemmelig API-hash gemt'
       ,fi: 'API salaisuus talletettu'
-      ,nb: 'API nøkkel lagret'
+      ,nb: 'API-nøkkel lagret'
       ,pl: 'Poufne klucz API zapisane'
       ,ru: 'Хэш пароля API сохранен'
       ,sk: 'Hash API hesla uložený'
@@ -2951,7 +2953,7 @@ function init() {
       ,ja: '食事編集'
       ,dk: 'Mad editor'
       ,fi: 'Muokkaa ruokia'
-      ,nb: 'Mat editor'
+      ,nb: 'Mat-editor'
       ,pl: 'Edytor posiłków'
       ,ru: 'Редактор продуктов'
       ,sk: 'Editor jedál'
@@ -3146,6 +3148,7 @@ function init() {
       }
     ,'Your API secret or token' : {
       fi: 'API salaisuus tai avain'
+      ,nb: 'Din API-nøkkel eller passord'
       ,pl: 'Twój hash API lub token'
       ,ru: 'Ваш пароль API или код доступа '
       ,de: 'Deine API-Prüfsumme oder Token'
@@ -3153,6 +3156,7 @@ function init() {
       }
     ,'Remember this device. (Do not enable this on public computers.)' : {
       fi: 'Muista tämä laite (Älä valitse julkisilla tietokoneilla)'
+      ,nb: 'Husk denne enheten (Ikke velg dette på offentlige eller delte datamaskiner)'
       , pl: 'Zapamiętaj to urządzenie (Nie używaj tej opcji korzystając z publicznych komputerów.)'
       ,ru: 'Запомнить это устройство (Не применяйте в общем доступе)'
       ,de: 'An dieses Gerät erinnern. (Nicht auf öffentlichen Geräten verwenden)'
@@ -3226,7 +3230,7 @@ function init() {
       ,ja: 'イベント'
       ,dk: 'Hændelsestype'
       ,fi: 'Tapahtumatyyppi'
-      ,nb: 'Type'
+      ,nb: 'Hendelsestype'
       ,he: 'סוג אירוע'
       ,pl: 'Typ zdarzenia'
       ,ru: 'Тип события'
@@ -3330,7 +3334,7 @@ function init() {
       ,ja: '摂取糖質量'
       ,dk: 'Antal kulhydrater'
       ,fi: 'Hiilihydraatit'
-      ,nb: 'Karbo'
+      ,nb: 'Karbohydrat'
       ,he: 'פחמימות שנאכלו'
       ,pl: 'Węglowodany spożyte'
       ,ru: 'Дано углеводов'
@@ -3382,7 +3386,7 @@ function init() {
       ,ja: 'イベント時間'
       ,dk: 'Tidspunkt for hændelsen'
       ,fi: 'Aika'
-      ,nb: 'Tidspunkt for hendelsen'
+      ,nb: 'Tidspunkt'
       ,he: 'זמן האירוע'
       ,pl: 'Czas zdarzenia'
       ,ru: 'Время события'
@@ -3461,7 +3465,7 @@ function init() {
       ,ja: 'ボーラス計算機能使用'
       ,dk: 'Anvend BS-korrektion i beregning'
       ,fi: 'Käytä korjausannosta laskentaan'
-      ,nb: 'Bruk blodsukkerkorrigering i beregning'
+      ,nb: 'Bruk blodsukkerkorrigering i beregningen'
       ,pl: 'Użyj BG w obliczeniach korekty'
       ,ru: 'При расчете учитывать коррекцию ГК'
       ,sk: 'Použite korekciu na glykémiu'
@@ -3643,7 +3647,7 @@ function init() {
       ,ja: '糖質量計算機能を使用'
       ,dk: 'Benyt kulhydratkorrektion i beregning'
       ,fi: 'Käytä hiilihydraattikorjausta laskennassa'
-      ,nb: 'Bruk karbohydratkorrigering i beregning'
+      ,nb: 'Bruk karbohydratkorrigering i beregningen'
       ,pl: 'Użyj wartość węglowodanów w obliczeniach korekty'
       ,ru: 'Пользоваться коррекцией на углеводы при расчете'
       ,sk: 'Použite korekciu na sacharidy'
@@ -3669,7 +3673,7 @@ function init() {
       ,ja: 'COB補正計算を使用'
       ,dk: 'Benyt aktive kulhydrater i beregning'
       ,fi: 'Käytä aktiivisia hiilihydraatteja laskennassa'
-      ,nb: 'Benytt aktive karbohydrater i beregning'
+      ,nb: 'Bruk aktive karbohydrater i beregningen'
       ,pl: 'Użyj COB do obliczenia korekty'
       ,ru: 'Учитывать активные углеводы COB при расчете'
       ,sk: 'Použite korekciu na COB'
@@ -3773,7 +3777,7 @@ function init() {
       ,ja: '治療にインスリン補正を入力する。'
       ,dk: 'Indtast insulinkorrektion'
       ,fi: 'Syötä insuliinikorjaus'
-      ,nb: 'Task inn insulinkorrigering'
+      ,nb: 'Angi insulinkorrigering'
       ,pl: 'Wprowadź wartość korekty w leczeniu'
       ,ru: 'Внести коррекцию инсулина в лечение'
       ,sk: 'Zadajte korekciu inzulínu do ošetrenia'
@@ -4187,7 +4191,7 @@ function init() {
       ,ja: '追加メモ、コメント'
       ,dk: 'Ekstra noter, kommentarer'
       ,fi: 'Lisähuomiot, kommentit'
-      ,nb: 'Ekstra notater, kommentarer'
+      ,nb: 'Notater'
       ,he: 'הערות נוספות'
       ,pl: 'Uwagi dodatkowe'
       ,ru: 'Дополнительные примечания'
@@ -4214,7 +4218,7 @@ function init() {
       ,ja: '振り返りモード'
       ,dk: 'Retro mode'
       ,fi: 'VANHENTUNEET TIEDOT'
-      ,nb: 'Retro mode'
+      ,nb: 'Retro-modus'
       ,nl: 'Retro mode'
       ,pl: 'Tryb RETRO'
       ,ru: 'режим РЕТРО'
@@ -4345,7 +4349,7 @@ function init() {
       ,ja: '報告'
       ,dk: 'Rapporteringsværktøj'
       ,fi: 'Raportointityökalu'
-      ,nb: 'Rapporteringsverktøy'
+      ,nb: 'Rapporter'
       ,pl: 'Raporty'
       ,ru: 'Отчеты'
       ,sk: 'Správy'
@@ -4898,7 +4902,7 @@ function init() {
       ,dk: 'Bolus Wizard (BWP)'
       ,it: 'BWP-Calcolatore di bolo'
       ,ja: 'BWP・ボーラスウィザード参照'
-      ,nb: 'Boluskalkulator'
+      ,nb: 'Boluskalkulator (BWP)'
       ,el: 'Εργαλείο Εκτίμησης Επάρκειας Ινσουλίνης (BWP)'
       ,ro: 'BWP-Sugestie de bolusare'
       ,bg: 'Болус калкулатор'
@@ -5540,7 +5544,7 @@ function init() {
       ,ja: 'CGM Sensor Stop'
       ,dk: 'CGM Sensor Stop'
       ,fi: 'CGM Sensor Stop'
-      ,nb: 'CGM Sensor Stop'
+      ,nb: 'CGM Sensor Stopp'
       ,he: 'CGM Sensor Stop'
       ,pl: 'CGM Sensor Stop'
       ,ru: 'Стоп сенсор'
@@ -5895,6 +5899,7 @@ function init() {
        ,dk: 'Udskift pumpebatteri'
        ,de: 'Pumpenbatterie wechseln'
        ,fi: 'Pumpun patterin vaihto'
+       ,nb: 'Bytte av pumpebatteri'
        ,bg: 'Смяна на батерия на помпата'
       ,hr: 'Zamjena baterije pumpe'
       ,ja: 'ポンプバッテリー交換'
@@ -5909,6 +5914,7 @@ function init() {
        ,dk: 'Pumpebatteri lav Alarm'
        ,de: 'Pumpenbatterie niedrig Alarm'
        ,fi: 'Varoitus! Pumpun patteri loppumassa'
+       ,nb: 'Pumpebatteri Lav alarm'
        ,bg: 'Аларма за слаба батерия на помпата'
       ,hr: 'Upozorenje slabe baterije pumpe'
        ,ja: 'ポンプバッテリーが低下'
@@ -5923,6 +5929,7 @@ function init() {
        ,dk: 'Pumpebatteri skal skiftes!'
        ,de: 'Pumpenbatterie Wechsel überfällig!'
        ,fi: 'Pumpun patterin vaihto myöhässä!'
+       ,nb: 'Pumpebatteriet må byttes!'
        ,bg: 'Смяната на батерията на помпата - наложителна'
       ,hr: 'Prošao je rok za zamjenu baterije pumpe!'
       ,ja: 'ポンプバッテリー交換期限切れてます！'
@@ -6352,7 +6359,7 @@ function init() {
       ,ja: '有効にすると、小さい白ドットが素のBGデータ用に表示されます'
       ,dk: 'Ved aktivering vil små hvide prikker blive vist for rå BG tal'
       ,fi: 'Aktivoituna raaka VS tieto piirtyy aikajanalle valkoisina pisteinä'
-      ,nb: 'Ved aktivering vil små hvite prikker bli vist for rå BG tall'
+      ,nb: 'Ved aktivering vil små hvite prikker bli vist for ubehandlede BG-data'
       ,pl: 'Gdy funkcja jest włączona, małe białe kropki pojawią się na surowych danych BG'
       ,ru: 'При активации данные RAW будут видны как мелкие белые точки'
       ,sk: 'Keď je povolené, malé bodky budú zobrazovať RAW dáta.'
@@ -6675,7 +6682,7 @@ function init() {
       ,ja: '時間前'
       ,dk: 'time siden'
       ,fi: 'tunti sitten'
-      ,nb: 'Time siden'
+      ,nb: 't siden'
       ,pl: 'godzina temu'
       ,ru: 'час назад'
       ,sk: 'hod. pred'
@@ -6702,7 +6709,7 @@ function init() {
       ,ja: '時間前'
       ,dk: 'timer siden'
       ,fi: 'tuntia sitten'
-      ,nb: 'Timer siden'
+      ,nb: 't siden'
       ,pl: 'godzin temu'
       ,ru: 'часов назад'
       ,sk: 'hod. pred'
@@ -6729,7 +6736,7 @@ function init() {
       ,ja: '分前'
       ,dk: 'minut siden'
       ,fi: 'minuutti sitten'
-      ,nb: 'minutter siden'
+      ,nb: 'min siden'
       ,pl: 'minuta temu'
       ,ru: 'мин назад'
       ,sk: 'min. pred'
@@ -6756,7 +6763,7 @@ function init() {
       ,ja: '分前'
       ,dk: 'minutter siden'
       ,fi: 'minuuttia sitten'
-      ,nb: 'minutter siden'
+      ,nb: 'min siden'
       ,pl: 'minut temu'
       ,ru: 'минут назад'
       ,sk: 'min. pred'
@@ -7279,7 +7286,7 @@ function init() {
       ,ro: 'ml'
       ,bg: 'мл'
       ,hr: 'ml'
-      ,nb: 'ml'
+      ,nb: 'mL'
       ,fi: 'ml'
       ,pl: 'ml'
       ,pt: 'mL'
@@ -7680,7 +7687,7 @@ function init() {
     ,'This task find and remove CGM data in the future created by uploader with wrong date/time.' : {
       cs: 'Tento úkol najde a odstraní CGM data v budoucnosti vzniklé špatně nastaveným datem v uploaderu.'
       ,he: 'משימה זו מוצאת נתונים של סנסור סוכר ומסירה אותם בעתיד, שנוצרו על ידי העלאת נתונים עם תאריך / שעה שגויים'
-      ,nb: 'Finn og fjern fremtidige cgm data lastet opp med feil dato/tid'
+      ,nb: 'Finn og fjern fremtidige cgm data som er lastet opp med feil dato/tid'
       ,fr: 'Cet outil cherche et efface les valeurs CGM dont la date est dans le futur'
       ,el: 'Αυτή η ενέργεια αφαιρεί δεδομένα αιθητήρα τα οποία εισήχθησαν με λάθος ημερομηνία και ώρα, από τη βάση δεδομένων'
       ,de: 'Finde und entferne CGM-Daten in der Zukunft, die vom Uploader mit falschem Datum/Uhrzeit erstellt wurden.'
@@ -7810,7 +7817,7 @@ function init() {
     ,'Error loading database' : {
       cs: 'Chyba při nahrávání databáze'
       ,he: 'שגיאה בטעינת מסד הנתונים '
-      ,nb: 'Feil udner lasting av database'
+      ,nb: 'Feil under lasting av database'
       ,fr: 'Erreur chargement de la base de données'
       ,de: 'Fehler beim Laden der Datenbank'
       ,es: 'Error al cargar base de datos'
@@ -8098,6 +8105,7 @@ function init() {
       ,de: 'Alle Dokumente der Gerätestatus-Sammlung löschen, die älter als 30 Tage sind'
       , pl: 'Usuń wszystkie dokumenty z kolekcji devicestatus starsze niż 30 dni'
       , hu: 'Az összes "devicestatus" dokumentum törlése ami 30 napnál öregebb'
+      
       }
     ,'Number of Days to Keep:' : {
       hr: 'Broj dana za sačuvati:'
@@ -8201,7 +8209,7 @@ function init() {
     ,'Admin Tools' : {
       cs: 'Nástroje pro správu'
       ,he: 'כלי אדמיניסטרציה '
-      ,nb: 'Administrasjonsoppgaver'
+      ,nb: 'Administrasjonsverktøy'
       ,ro: 'Instrumente de administrare'
       ,de: 'Administrator-Werkzeuge'
       ,es: 'Herramientas Administrativas'
@@ -8228,7 +8236,7 @@ function init() {
     ,'Nightscout reporting' : {
       cs: 'Nightscout - Výkazy'
       ,he: 'דוחות נייססקאוט'
-      ,nb: 'Nightscout - rapporter'
+      ,nb: 'Rapporter'
       ,ro: 'Rapoarte Nightscout'
       ,fr: 'Rapports Nightscout'
       ,el: 'Αναφορές'
@@ -8460,7 +8468,7 @@ function init() {
       ,es: 'Basal modificado en %'
       ,dk: 'Basal ændring i %'
       ,it: 'Variazione basale in %'
-      ,nb: 'Basal endring i %'
+      ,nb: 'Basal-endring i %'
       ,fi: 'Basaalimuutos prosenteissa'
       ,pl: 'Zmiana dawki podstawowej w %'
       ,pt: 'Mudança de basal em %'
@@ -8806,7 +8814,7 @@ function init() {
       ,de: 'Eintrag gültig ab'
       ,es: 'Registro válido desde'
       ,dk: 'Hændelse gyldig fra'
-      ,nb: 'Rad gyldig fra'
+      ,nb: 'Oppføring gyldig fra'
       ,fi: 'Merkintä voimassa alkaen'
       ,bg: 'Записът е валиден от '
       ,hr: 'Zapis vrijedi od'
@@ -8878,7 +8886,7 @@ function init() {
       ,fr: 'Durée d\'action de l\'insuline'
       ,el: 'Διάρκεια Δράσης Ινσουλίνης(DIA)'
       ,sv: 'Verkningstid för insulin (DIA)'
-      ,nb: 'Insulin varighet'
+      ,nb: 'Insulin-varighet (DIA)'
       ,de: 'Dauer der Insulinaktivität (DIA)'
       ,es: 'Duración Insulina Activa (DIA)'
       ,dk: 'Varighed af insulin aktivitet (DIA)'
@@ -8906,7 +8914,7 @@ function init() {
       ,de: 'Entspricht der typischen Dauer in der das Insulin wirkt. Variiert je nach Patient und Insulintyp. Häufig 3-4 Stunden für die meisten Pumpeninsuline und die meisten Patienten. Manchmal auch Insulin-Wirkungsdauer genannt.'
       ,dk: 'Representerer den typiske tid hvor insulinen virker. Varierer per patient og per insulin type. Typisk 3-4 timer for de fleste pumpe insulin og for de fleste patienter. Nogle gange kaldes dette også insulin-livs-tid.'
       ,sv: 'Beskriver under hur lång tid insulinet verkar. Varierar mellan patienter. Typisk varaktighet 3-4 timmar.'
-      ,nb: 'Representerer typisk insulinvarighet. Varierer per pasient og per insulin type. Vanligvis 3-4 timer for de fleste typer insulin og de fleste pasientene. Noen ganger også kalt insulinlevetid.'
+      ,nb: 'Representerer typisk insulinvarighet. Varierer per pasient og per insulintype. Vanligvis 3-4 timer for de fleste typer insulin og de fleste pasientene. Noen ganger også kalt insulin-levetid eller Duration of Insulin Activity, DIA.'
       ,fi: 'Kertoo insuliinin tyypillisen vaikutusajan. Vaihtelee potilaan ja insuliinin tyypin mukaan. Tyypillisesti 3-4 tuntia pumpuissa käytettävällä insuliinilla.'
       ,bg: 'Представя типичната продължителност на действието на инсулина. Варира между отделните пациенти и различни инсулини. Обикновено е 3-4 часа за пациентите с помпа. Нарича се още живот на инсулина '
       ,hr: 'Predstavlja uobičajeno trajanje djelovanje inzulina. Varira po vrstama inzulina i osobama. Tipično je to 3-4 sata za inzuline u pumpama za većinu osoba. Ponekad se naziva i vijek inzulina' 
@@ -9002,7 +9010,7 @@ function init() {
       ,ro: 'g/oră'
       ,fr: 'g/heure'
       ,sv: 'g/timme'
-      ,nb: 'g/t'
+      ,nb: 'g/time'
       ,de: 'g/Std'
       ,es: 'gr/hora'
       ,dk: 'g/time'
@@ -9055,7 +9063,7 @@ function init() {
       ,el: 'Ευαισθησία στην Ινοσυλίνη (ISF)'
       ,sv: 'Insulinkänslighetsfaktor (ISF)'
       ,dk: 'Insulinfølsomhedsfaktor (ISF)'
-      ,nb: 'Insulinfølsomhetsfaktor'
+      ,nb: 'Insulinfølsomhetsfaktor (ISF)'
       ,fi: 'Insuliiniherkkyys (ISF)'
       ,bg: 'Фактор на инсулинова чувствителност ISF '
       ,hr: 'Faktor inzulinske osjetljivosti (ISF)'
@@ -9080,7 +9088,7 @@ function init() {
       ,es: 'mg/dl o mmol/L por unidad Insulina. La relación de la caída de glucosa y cada unidad de insulina de corrección administrada.'
       ,sv: 'mg/dl eller mmol per enhet insulin. Hur varje enhet insulin sänker blodsockret'
       ,dk: 'mg/dl eller mmol per enhed insulin. Beskriver hvor mange mmol eller mg/dl blodsukkeret sænkes per enhed insulin (Insulinfølsomheden)'
-      ,nb: 'mg/dl eller mmol/l per enhet insulin.  Beskriver hvor mye blodsukkeret senkes per enhet insulin.'
+      ,nb: 'mg/dl eller mmol/L per enhet insulin.  Beskriver hvor mye blodsukkeret senkes per enhet insulin.'
       ,fi: 'mg/dL tai mmol/L / 1 yksikkö insuliinia. Suhde, joka kertoo montako yksikköä verensokeria yksi yksikkö insuliinia laskee.'
       ,bg: 'мг/дл или ммол към 1 единица инсулин. Съотношението как се променя кръвната захар със всяка единица инсулинова корекция'
       ,hr: 'md/dL ili mmol/L po jedinici inzulina. Omjer koliko se GUK mijenja sa jednom jedinicom korekcije inzulina.'
@@ -9155,7 +9163,7 @@ function init() {
       ,es: 'Tasas basales [Unidad/hora]'
       ,fr: 'Débit basal (Unités/ heure)'
       ,sv: 'Basal [enhet/t]'
-      ,nb: 'Basal [enhet/t]'
+      ,nb: 'Basal [enhet/time]'
       ,fi: 'Basaali [yksikköä/tunti]'
       ,bg: 'Базална стойност [единица/час]'
       ,hr: 'Bazali [jedinica/sat]'
@@ -9180,7 +9188,7 @@ function init() {
       ,es: 'Intervalo glucemia dentro del objetivo [mg/dL,mmol/L]'
       ,fr: 'Cible d\'intervalle de glycémie'
       ,sv: 'Önskvärt blodsockerintervall [mg/dl,mmol]'
-      ,nb: 'Ønsket blodsukkerintervall [mg/dl,mmmol/l]'
+      ,nb: 'Ønsket blodsukkerintervall [mg/dl, mmmol/L]'
       ,fi: 'Tavoitealue [mg/dL tai mmol/L]'
       ,bg: 'Целеви диапазон на КЗ [мг/дл , ммол]'
       ,hr: 'Ciljani raspon GUK [mg/dL,mmol/L]'
@@ -9474,7 +9482,7 @@ function init() {
     ,'Save current record before switching to new?' : {
       cs: 'Uložit současný záznam před přepnutím na nový?'
       ,he: 'שמור את הרשומה הנוכחית לפני המעבר ל חדש? '
-      ,nb: 'Lagre før nytte til ny?'
+      ,nb: 'Lagre før bytte til ny?'
       ,fr: 'Sauvegarder cetter entrée avant de procéder à l\'entrée suivante?'
       ,el: 'Αποθήκευση αλλαγών πριν γίνει εναλλαγή στο νέο προφίλ? '
       ,de: 'Aktuellen Datensatz speichern?'
@@ -9549,7 +9557,7 @@ function init() {
     ,'I:C' : {
       cs: 'I:C'
       ,he:  'יחס אינסולין לפחמימות '
-      ,nb: 'IKH'
+      ,nb: 'IK'
       ,fr: 'I:C'
       ,ro: 'ICR'
       ,de: 'IE:KH'
@@ -9933,7 +9941,7 @@ function init() {
       ,fr: 'Modifier l\'horaire des glucides? Nouveau: %1'
       ,el: 'Αλλαγή του χρόνου πρόσληψης υδατανθράκων σε %1?'
       ,sv: 'Ändra kolhydratstid till %1 ?'
-      ,nb: 'Endre Karbohydrattid til %1 ?'
+      ,nb: 'Endre karbohydrattid til %1 ?'
       ,bg: 'Да променя ли времето на ВХ с %1?'
       ,hr: 'Promijeni vrijeme UGH na %1?'
       ,fi: 'Muuta hiilihydraattien aika? Uusi: %1'
@@ -10058,7 +10066,7 @@ function init() {
       ,es: 'Gráfica'
       ,el: 'Απεικόνιση'
       ,sv: 'Rendering'
-      ,nb: 'Rendering'
+      ,nb: 'Tegner grafikk'
       ,bg: 'Показване на графика'
       ,hr: 'Iscrtavanje'
       ,fi: 'Piirrän graafeja'
@@ -11473,7 +11481,7 @@ function init() {
       ,ru: 'Остается актуального временного базала'
       ,sk: 'Zostatok dočasného bazálu'
       ,sv: 'Återstående tempbasaltid'
-      ,nb: 'Gjenstående midlertidig basal tid'
+      ,nb: 'Gjenstående tid for midlertidig basal'
       ,pt: 'Basal temporária ativa restante'
       ,es: 'Basal temporal activa restante'
       ,fi: 'Aktiivista tilapäisbasaalia jäljellä'
@@ -11616,7 +11624,7 @@ function init() {
       ,fr: 'Différence de glycémie'
       ,ru: 'Изменение гликемии'
       ,sv: 'BS deltavärde'
-      ,nb: 'BS forskjell'
+      ,nb: 'BS deltaverdi'
       ,fi: 'VS muutos'
       ,pt: 'Diferença de glicemia'
       ,es: 'Diferencia de glucemia'
@@ -11845,7 +11853,7 @@ function init() {
       ,es: 'Ignorar alarma de Hiperglucemia al tener suficiente insulina activa'
       ,ru: 'Отключение предупреждение о высоком СК ввиду достаточности инсулина в организме'
       ,sv: 'Snoozar höglarm då aktivt insulin är tillräckligt'
-      ,nb: 'Utsetter høyalarm siden det er nok aktivt insulin'
+      ,nb: 'Utsetter høy-alarm siden det er nok aktivt insulin'
       ,fi: 'Korkean sokerin varoitus poistettu riittävän insuliinin vuoksi'
       ,pt: 'Ignorar alarme de hiper em função de IOB suficiente'
       ,sk: 'Odloženie alarmu vysokej glykémie, pretože je dostatok IOB'
@@ -12230,7 +12238,7 @@ function init() {
       ,hr: 'Procjena GUK %1 cilja'
       ,ru: 'Расчетная целевая гликемия %1'
       ,sv: 'Önskat BS %1 mål'
-      ,nb: 'Ønsket BS %1 mål'
+      ,nb: 'Predikert BS %1 mål'
       ,fi: 'Laskettu VS %1 tavoitteen'
       ,pt: 'Meta de glicemia estimada %1'
       ,sk: 'Predpokladaná glykémia %1 cieľ'
@@ -12543,7 +12551,7 @@ function init() {
       ,fr: 'CAGE'
       ,ru: 'КатПомп'
       ,sv: 'Nål'
-      ,nb: 'Nål alder'
+      ,nb: 'Nålalder'
       ,fi: 'KIKÄ'
       ,pt: 'ICAT'
       ,es: 'Cánula desde'
@@ -12953,7 +12961,7 @@ function init() {
       ,bg: 'преди %1 час'
       ,hr: 'prije %1 sati'
       ,sv: '%1h sedan'
-      ,nb: '%1h siden'
+      ,nb: '%1t siden'
       ,fi: '%1h sitten'
       ,pt: '%1h atrás'
       ,es: '%1h. atrás'
@@ -13098,7 +13106,7 @@ function init() {
       ,bg: 'Смени/рестартирай сензора скоро'
       ,hr: 'Zamijena/restart senzora uskoro'
       ,sv: 'Byt/starta om sensorn snart'
-      ,nb: 'Bytt/restarta sensoren snart'
+      ,nb: 'Bytt/restart sensoren snart'
       ,fi: 'Vaihda/käynnistä sensori uudelleen pian'
       ,pt: 'Mudar/reiniciar sensor em breve'
       ,es: 'Cambiar/Reiniciar sensor en breve'
@@ -13122,7 +13130,7 @@ function init() {
       ,bg: 'Сензорът е на %1 дни %2 часа '
       ,hr: 'Starost senzora %1 dana i %2 sati'
       ,sv: 'Sensorålder %1 dagar %2 timmar'
-      ,nb: 'Sensoralder %1 dag %2 timer'
+      ,nb: 'Sensoralder %1 dager %2 timer'
       ,fi: 'Sensorin ikä %1 päivää, %2 tuntia'
       ,pt: 'Idade do sensor %1 dias %2 horas'
       ,es: 'Sensor desde %1 días %2 horas'
@@ -13227,6 +13235,7 @@ function init() {
       ,pl: 'podawanie insuliny'
       ,tr: 'İnsülin dağılımı'
       ,hu: 'Inzulin disztribúció'
+      ,nb: 'Insulinfordeling'
     }
     ,'To see this report, press SHOW while in this view' : {
       cs: 'Pro zobrazení toho výkazu stiskněte Zobraz na této záložce'
@@ -13248,6 +13257,7 @@ function init() {
       ,pl: 'Aby wyświetlić ten raport, naciśnij przycisk POKAŻ w tym widoku'
       ,tr: 'Bu raporu görmek için bu görünümde GÖSTER düğmesine basın.'
       ,hu: 'A jelentés megtekintéséhez kattints a MUTASD gombra'
+      ,nb: 'Klikk på "VIS" for å se denne rapporten'
     }
     ,'AR2 Forecast' : {
       cs: 'AR2 predikci'
@@ -13269,6 +13279,7 @@ function init() {
       ,pl: 'Prognoza AR2'
       ,tr: 'AR2 Tahmini'
       ,hu: 'AR2 előrejelzés'
+      ,nb: 'AR2-prediksjon'
     }
     ,'OpenAPS Forecasts' : {
       cs: 'OpenAPS predikci'
@@ -13290,6 +13301,7 @@ function init() {
       ,pl: 'Prognoza OpenAPS'
       ,tr: 'OpenAPS Tahminleri'
       ,hu: 'OpenAPS előrejelzés'
+      ,nb: 'OpenAPS-prediksjon'
      }
     ,'Temporary Target' : {
       cs: 'Dočasný cíl glykémie'
@@ -13311,6 +13323,7 @@ function init() {
       ,pl: 'Cel tymczasowy'
       ,tr: 'Geçici Hedef'
       ,hu: 'Átmeneti cél'
+      ,nb: 'Midlertidig mål'
     }
     ,'Temporary Target Cancel' : {
       cs: 'Dočasný cíl glykémie konec'
@@ -13332,6 +13345,7 @@ function init() {
       ,pl: 'Zel tymczasowy anulowany'
       ,tr: 'Geçici Hedef İptal'
       ,hu: 'Átmeneti cél törlése'
+      ,nb: 'Avslutt midlertidig mål'
     }
     ,'OpenAPS Offline' : {
       cs: 'OpenAPS vypnuto'
@@ -13353,6 +13367,7 @@ function init() {
       ,pl: 'OpenAPS nieaktywny'
       ,tr: 'OpenAPS Offline (çevrimdışı)'
       ,hu: 'OpenAPS nem elérhető (offline)'
+      ,nb: 'OpenAPS offline'
     }
     ,'Profiles' : {
       cs: 'Profily'
@@ -13369,6 +13384,7 @@ function init() {
       ,nl: 'Profielen'
       ,zh_cn: '配置文件'
       ,sv: 'Profiler'
+      ,nb: 'Profiler'
       ,bg: 'Профили'
       ,hr: 'Profili'
       ,pl: 'Profile'
@@ -13395,6 +13411,7 @@ function init() {
       ,pl: 'Czas fluaktacji (odchyleń)'
       ,tr: 'Dalgalanmada geçen süre'
       ,hu: 'Kilengésben töltött idő'
+      ,nb: 'Tid i fluktuasjon'
     }
     ,'Time in rapid fluctuation' : {
       cs: 'Doba rychle se měnící glykémie'
@@ -13416,6 +13433,7 @@ function init() {
       ,pl: 'Czas szybkich fluaktacji (odchyleń)'
       ,tr: 'Hızlı dalgalanmalarda geçen süre'
       ,hu: 'Magas kilengésekben töltött idő'
+      ,nb: 'Tid i hurtig fluktuasjon'
     }
     ,'This is only a rough estimation that can be very inaccurate and does not replace actual blood testing. The formula used is taken from:' : {
       cs: 'Toto je pouze hrubý odhad, který může být nepřesný a nenahrazuje kontrolu z krve. Vzorec je převzatý z:'
@@ -13437,6 +13455,7 @@ function init() {
       ,pl: 'To tylko przybliżona ocena, która może być bardzo niedokładna i nie może zastąpić faktycznego poziomu cukru we krwi. Zastosowano formułę:'
       ,tr: 'Bu bir kaba tahmindir ve çok hata içerebilir gerçek kan şekeri testlerinin yerini tutmayacaktır. Kullanılan formülde buradandır:'
       ,hu: 'Ez egy nagyon durva számítás ami nem pontos és nem helyettesíti a cukorszint mérését. A képlet a következő helyről lett véve:'
+      ,nb: 'Dette er kun et grovt estimat som kan være misvisende. Det erstatter ikke en blodprøve. Formelen er hentet fra:'
     }
     , 'Filter by hours' : {
       cs: ' Filtr podle hodin'
@@ -13457,6 +13476,7 @@ function init() {
       ,pl: 'Filtruj po godzinach'
       ,tr: 'Saatlere göre filtrele'
       ,hu: 'Megszűrni órák alapján'
+      ,nb: 'Filtrer per time'
     }
     , 'Time in fluctuation and Time in rapid fluctuation measure the % of time during the examined period, during which the blood glucose has been changing relatively fast or rapidly. Lower values are better.' : {
       cs: 'Doba měnící se glykémie a rapidně se měnící glykémie měří % času ve zkoumaném období, během kterého se glykémie měnila relativně rychle nebo rapidně. Nižší hodnota je lepší.'
@@ -13477,6 +13497,7 @@ function init() {
       ,pl: 'Czas fluktuacji i szybki czas fluktuacji mierzą % czasu w badanym okresie, w którym poziom glukozy we krwi zmieniał się szybko lub bardzo szybko. Preferowane są wolniejsze zmiany'
       ,tr: 'Dalgalanmadaki zaman ve Hızlı dalgalanmadaki zaman, kan şekerinin nispeten hızlı veya çok hızlı bir şekilde değiştiği, incelenen dönemdeki zamanın %\'sini ölçer. Düşük değerler daha iyidir.'
       ,hu: 'A sima és magas kilengésnél mért idő százalékban kifelyezve, ahol a cukorszint aránylag nagyokat változott. A kisebb értékek jobbak ebben az esetben'
+       ,nb: 'Tid i fluktuasjon og tid i hurtig fluktuasjon måler % av tiden i den aktuelle periodn der blodsukkeret har endret seg relativt raskt. Lave verdier er best.'
     }
     , 'Mean Total Daily Change is a sum of the absolute value of all glucose excursions for the examined period, divided by the number of days. Lower is better.' : {
       cs: 'Průměrná celková denní změna je součet absolutních hodnoty všech glykémií za sledované období, děleno počtem dní. Nižší hodnota je lepší.'
@@ -13497,6 +13518,8 @@ function init() {
       ,pl: 'Sednia całkowita dziennych zmian jest sumą wszystkich zmian glikemii w badanym okresie, podzielonym przez liczbę dni. Mniejsze są lepsze'
       ,tr: 'Toplam Günlük Değişim, incelenen süre için, gün sayısına bölünen tüm glukoz değerlerinin mutlak değerinin toplamıdır. Düşük değer daha iyidir.'
       ,hu: 'Az átlagos napi változás az abszolút értékek összege elosztva a napok számával. A kisebb érték jobb ebben az esetben.'
+      ,nb: 'Gjennomsnitt total daglig endring er summen av absolutverdier av alle glukoseendringer i den aktuelle perioden, divideret med antall dager. Lave verdier er best.'
+
     }
     , 'Mean Hourly Change is a sum of the absolute value of all glucose excursions for the examined period, divided by the number of hours in the period. Lower is better.' : {
       cs: 'Průměrná hodinová změna je součet absolutní hodnoty všech glykémií za sledované období, dělených počtem hodin v daném období. Nižší hodnota je lepší.'
@@ -13517,7 +13540,32 @@ function init() {
       ,pl: 'Sednia całkowita godzinnych zmian jest sumą wszystkich zmian glikemii w badanym okresie, podzielonym przez liczbę godzin. Mniejsze są lepsze'
       ,tr: 'Saat başına ortalama değişim, gözlem periyodu üzerindeki tüm glikoz değişikliklerinin mutlak değerlerinin saat sayısına bölünmesiyle elde edilen toplam değerdir. Düşük değerler daha iyidir.'
       ,hu: 'Az átlagos óránkénti változás az abszút értékek összege elosztva a napok számával. A kisebb érték jobb ebben az esetben.'
+      ,nb: 'Gjennomsnitt endring per time er summen av absoluttverdier av alle glukoseendringer i den aktuelle perioden divideret med antall timer. Lave verdier er best.'
     }
+    , 'Out of Range RMS is calculated by squaring the distance out of range for all glucose readings for the examined period, summing them, dividing by the count and taking the square root. This metric is similar to in-range percentage but weights readings far out of range higher. Lower values are better.' : {
+      cs: 'Out of Range RMS is calculated by squaring the distance out of range for all glucose readings for the examined period, summing them, dividing by the count and taking the square root. This metric is similar to in-range percentage but weights readings far out of range higher. Lower values are better.'
+      ,he: 'Out of Range RMS is calculated by squaring the distance out of range for all glucose readings for the examined period, summing them, dividing by the count and taking the square root. This metric is similar to in-range percentage but weights readings far out of range higher. Lower values are better.'
+      ,nb: 'Out of Range RMS er beregnet ved å ta kvadratet av avstanden utenfor målområdet for alle blodsukkerverdier i den aktuelle perioden, summere dem, dele på antallet, og ta kvadratroten av resultatet. Dette målet er lignende som prodentvis tid i målområdet, men vekter målinger som ligger langt utenfor målområdet høyere. Lave verdier er best.'
+      ,ro: 'Out of Range RMS is calculated by squaring the distance out of range for all glucose readings for the examined period, summing them, dividing by the count and taking the square root. This metric is similar to in-range percentage but weights readings far out of range higher. Lower values are better.'
+      ,de: 'Out of Range RMS is calculated by squaring the distance out of range for all glucose readings for the examined period, summing them, dividing by the count and taking the square root. This metric is similar to in-range percentage but weights readings far out of range higher. Lower values are better.'
+      ,dk: 'Out of Range RMS is calculated by squaring the distance out of range for all glucose readings for the examined period, summing them, dividing by the count and taking the square root. This metric is similar to in-range percentage but weights readings far out of range higher. Lower values are better.'
+      ,es: 'Out of Range RMS is calculated by squaring the distance out of range for all glucose readings for the examined period, summing them, dividing by the count and taking the square root. This metric is similar to in-range percentage but weights readings far out of range higher. Lower values are better.'
+      ,fr: 'Out of Range RMS is calculated by squaring the distance out of range for all glucose readings for the examined period, summing them, dividing by the count and taking the square root. This metric is similar to in-range percentage but weights readings far out of range higher. Lower values are better.'
+      ,sv: 'Out of Range RMS is calculated by squaring the distance out of range for all glucose readings for the examined period, summing them, dividing by the count and taking the square root. This metric is similar to in-range percentage but weights readings far out of range higher. Lower values are better.'
+      ,fi: 'Out of Range RMS is calculated by squaring the distance out of range for all glucose readings for the examined period, summing them, dividing by the count and taking the square root. This metric is similar to in-range percentage but weights readings far out of range higher. Lower values are better.'
+      ,bg: 'Out of Range RMS is calculated by squaring the distance out of range for all glucose readings for the examined period, summing them, dividing by the count and taking the square root. This metric is similar to in-range percentage but weights readings far out of range higher. Lower values are better.'
+      ,hr: 'Out of Range RMS is calculated by squaring the distance out of range for all glucose readings for the examined period, summing them, dividing by the count and taking the square root. This metric is similar to in-range percentage but weights readings far out of range higher. Lower values are better.'
+      ,pl: 'Out of Range RMS is calculated by squaring the distance out of range for all glucose readings for the examined period, summing them, dividing by the count and taking the square root. This metric is similar to in-range percentage but weights readings far out of range higher. Lower values are better.'
+      ,pt: 'Out of Range RMS is calculated by squaring the distance out of range for all glucose readings for the examined period, summing them, dividing by the count and taking the square root. This metric is similar to in-range percentage but weights readings far out of range higher. Lower values are better.'
+      ,nl: 'Out of Range RMS is calculated by squaring the distance out of range for all glucose readings for the examined period, summing them, dividing by the count and taking the square root. This metric is similar to in-range percentage but weights readings far out of range higher. Lower values are better.'
+      ,ru: 'Out of Range RMS is calculated by squaring the distance out of range for all glucose readings for the examined period, summing them, dividing by the count and taking the square root. This metric is similar to in-range percentage but weights readings far out of range higher. Lower values are better.'
+      ,sk: 'Out of Range RMS is calculated by squaring the distance out of range for all glucose readings for the examined period, summing them, dividing by the count and taking the square root. This metric is similar to in-range percentage but weights readings far out of range higher. Lower values are better.'
+      ,ko: 'Out of Range RMS is calculated by squaring the distance out of range for all glucose readings for the examined period, summing them, dividing by the count and taking the square root. This metric is similar to in-range percentage but weights readings far out of range higher. Lower values are better.'
+      ,it: 'Out of Range RMS is calculated by squaring the distance out of range for all glucose readings for the examined period, summing them, dividing by the count and taking the square root. This metric is similar to in-range percentage but weights readings far out of range higher. Lower values are better.'
+      ,tr: 'Out of Range RMS is calculated by squaring the distance out of range for all glucose readings for the examined period, summing them, dividing by the count and taking the square root. This metric is similar to in-range percentage but weights readings far out of range higher. Lower values are better.'
+      ,zh_cn: 'Out of Range RMS is calculated by squaring the distance out of range for all glucose readings for the examined period, summing them, dividing by the count and taking the square root. This metric is similar to in-range percentage but weights readings far out of range higher. Lower values are better.'
+      ,hu: 'Out of Range RMS is calculated by squaring the distance out of range for all glucose readings for the examined period, summing them, dividing by the count and taking the square root. This metric is similar to in-range percentage but weights readings far out of range higher. Lower values are better.'
+      }
     , 'GVI (Glycemic Variability Index) and PGS (Patient Glycemic Status) are measures developed by Dexcom, detailed <a href="' : {
      cs: 'GVI (Glycemic Variability Index) a PGS (Patient Glycemic Status) jsou měření vyvinutá společností Dexcom, podrobněji <a href="'
      ,he: 'GVI (Glycemic Variability Index) and PGS (Patient Glycemic Status) are measures developed by Dexcom, detailed <a href="'
@@ -13538,6 +13586,7 @@ function init() {
      ,pl: 'GVI (Glycemic Variability Index) i PGS (Patient Glycemic Status) są pomiarami opracowanymi przez Dexcom, szczegóły <a href="'
      ,tr: 'GVI ve PGS Dexcom tarafından geliştirilen önlemlerdir, detaylı  <a href="'
      ,hu: 'GVI (Glycemic Variability Index) and PGS (Patient Glycemic Status) a dexcom cég által fejlesztett mérések, részletek <a href="'
+     ,nb: 'GVI (Glycemic Variability Index) og PGS (Patient Glycemic Status) er verdier utviklet av Dexcom, detaljer <a href="'
     }
     , '">can be found here</a>.' : {
      cs: '">zde</a>.'
@@ -13559,6 +13608,7 @@ function init() {
      ,pl: '">tutaj</a>.'
      ,tr: '">buradan</a>.'
      ,hu: '">itt találhatóak</a>.'
+     ,nb: '">her</a>.'
     }
     , 'Mean Total Daily Change' : {
       cs: 'Průměrná celková denní změna'
@@ -13580,6 +13630,7 @@ function init() {
       ,pl: 'Średnia całkowita dziennych zmian'
       ,tr: 'Günde toplam ortalama değişim'
       ,hu: 'Áltagos napi változás'
+       ,nb: 'Gjennomsnitt total daglig endring'
     }
     , 'Mean Hourly Change' : {
       cs: 'Průměrná hodinová změna'
@@ -13601,6 +13652,7 @@ function init() {
       ,pl: 'Średnia całkowita godzinnych zmian'
       ,tr: 'Saatte ortalama değişim'
       ,hu: 'Átlagos óránkénti változás'
+      ,nb: 'Gjennomsnitt endring per time'
     }
       , 'FortyFiveDown': {
           bg: 'slightly dropping'
@@ -13752,7 +13804,7 @@ function init() {
         , hr:  'brzo padajuće'
         , it:  'rapida diminuzione'
         , ko:  'rapidly dropping'
-        , nb:  'hurtig stigende'
+        , nb:  'hurtig fallende'
         , pl:  'szybko spada'
         , pt:  'rapidly dropping'
         , ro:  'scădere bruscă'
@@ -13779,7 +13831,7 @@ function init() {
         , hr:  'brzo rastuće'
         , it:  'rapido aumento'
         , ko:  'rapidly rising'
-        , nb:  'hurtig fallende'
+        , nb:  'hurtig stigende'
         , pl:  'szybko rośnie'
         , pt:  'rapidly rising'
         , ro:  'creștere rapidă'
@@ -15268,6 +15320,7 @@ function init() {
         ,tr: 'Yağ [g]'
         ,he: '[g] שמן'
         ,hu: 'Zsír [g]'
+        ,nb: 'Fett [g]'
     },
     'Protein [g]': {
         cs: 'Proteiny [g]'
@@ -15289,6 +15342,7 @@ function init() {
         ,tr: 'Protein [g]'
         ,he: '[g] חלבון'
         ,hu: 'Protein [g]'
+        ,nb: 'Protein [g]'
     },
     'Energy [kJ]': {
         cs: 'Energie [kJ]'
@@ -15310,6 +15364,7 @@ function init() {
       ,tr: 'Enerji [kJ]'
       ,he: '[kJ] אנרגיה'
       ,hu: 'Energia [kJ]'
+      ,nb: 'Energi [kJ]'
     },
     'Clock Views:': {
        cs: 'Hodiny:'
@@ -15331,6 +15386,7 @@ function init() {
       ,tr: 'Saat Görünümü'
       ,he: 'צגים השעון'
       ,hu: 'Óra:'
+      ,nb: 'Klokkevisning:'
     },
     'Clock': {
        cs: 'Hodiny'
@@ -15351,6 +15407,7 @@ function init() {
       ,tr: 'Saat'
       ,he: 'שעון'
       ,hu: 'Óra:'
+      ,nb: 'Klokke'
     },
     'Color': {
        cs: 'Barva'
@@ -15371,6 +15428,7 @@ function init() {
       ,tr: 'Renk'
       ,he: 'צבע'
       ,hu: 'Szinek'
+      ,nb: 'Farge'
     },
     'Simple': {
        cs: 'Jednoduchý'
@@ -15391,8 +15449,9 @@ function init() {
        ,tr: 'Basit'
        ,he: 'פשוט'
        ,hu: 'Csak cukor'
+       ,nb: 'Enkel'
     },
-    'TDD average': {
+    'TDD average' : {
       cs: 'Průměrná denní dávka'
       , fi: 'Päivän kokonaisinsuliinin keskiarvo'
       , ko: 'TDD average'
@@ -15409,7 +15468,80 @@ function init() {
       , ru: 'средняя суточная доза инсулина'
       , tr: 'Ortalama günlük Toplam Doz (TDD)'
       , hu: 'Átlagos napi adag (TDD)'
+      , nb: 'Gjennomsnitt TDD'
     },
+    'Bolus average' : {
+      cs: 'Bolus average'
+      ,he: 'Bolus average'
+      ,nb: 'Gjennomsnitt bolus'
+      ,ro: 'Bolus average'
+      ,de: 'Bolus average'
+      ,dk: 'Bolus average'
+      ,es: 'Bolus average'
+      ,fr: 'Bolus average'
+      ,sv: 'Bolus average'
+      ,fi: 'Bolus average'
+      ,bg: 'Bolus average'
+      ,hr: 'Bolus average'
+      ,pl: 'Bolus average'
+      ,pt: 'Bolus average'
+      ,nl: 'Bolus average'
+      ,ru: 'Bolus average'
+      ,sk: 'Bolus average'
+      ,ko: 'Bolus average'
+      ,it: 'Bolus average'
+      ,tr: 'Bolus average'
+      ,zh_cn: 'Bolus average'
+      ,hu: 'Bolus average'
+      },
+	  'Basal average' : {
+      cs: 'Basal average'
+      ,he: 'Basal average'
+      ,nb: 'Gjennomsnitt basal'
+      ,ro: 'Basal average'
+      ,de: 'Basal average'
+      ,dk: 'Basal average'
+      ,es: 'Basal average'
+      ,fr: 'Basal average'
+      ,sv: 'Basal average'
+      ,fi: 'Basal average'
+      ,bg: 'Basal average'
+      ,hr: 'Basal average'
+      ,pl: 'Basal average'
+      ,pt: 'Basal average'
+      ,nl: 'Basal average'
+      ,ru: 'Basal average'
+      ,sk: 'Basal average'
+      ,ko: 'Basal average'
+      ,it: 'Basal average'
+      ,tr: 'Basal average'
+      ,zh_cn: 'Basal average'
+      ,hu: 'Basal average'
+      },
+	  'Base basal average:' : {
+      cs: 'Base basal average'
+      ,he: 'Base basal average'
+      ,nb: 'Programmert gj.snitt basal'
+      ,ro: 'Base basal average'
+      ,de: 'Base basal average'
+      ,dk: 'Base basal average'
+      ,es: 'Base basal average'
+      ,fr: 'Base basal average'
+      ,sv: 'Base basal average'
+      ,fi: 'Base basal average'
+      ,bg: 'Base basal average'
+      ,hr: 'Base basal average'
+      ,pl: 'Base basal average'
+      ,pt: 'Base basal average'
+      ,nl: 'Base basal average'
+      ,ru: 'Base basal average'
+      ,sk: 'Base basal average'
+      ,ko: 'Base basal average'
+      ,it: 'Base basal average'
+      ,tr: 'Base basal average'
+      ,zh_cn: 'Base basal average'
+      ,hu: 'Base basal average'
+      },
     'Carbs average': {
       cs: 'Průměrné množství sacharidů'
       , fi: 'Hiilihydraatit keskiarvo'
@@ -15428,6 +15560,7 @@ function init() {
       , tr: 'Günde ortalama karbonhidrat'
       , he: 'פחמימות ממוצע'
       , hu: 'Szenhidrát átlag'
+      , nb: 'Gjennomsnitt totale karbohydrater'
     },
     'Eating Soon': {
       cs: 'Blížící se jídlo'
@@ -15447,6 +15580,7 @@ function init() {
       , tr: 'Yakında Yenecek'
       , he: 'אוכל בקרוב'
       , hu: 'Hamarosan evés'
+      , nb: 'Spiser snart'
     },
     'Last entry {0} minutes ago': {
       cs: 'Poslední hodnota {0} minut zpět'
@@ -15465,6 +15599,7 @@ function init() {
       , ru: 'предыдущая запись {0} минут назад'
       , tr: 'Son giriş {0} dakika önce'
       , hu: 'Utolsó bejegyzés {0} volt'
+      , dk: 'Siste verdi {0} minutter siden'
     },
     'change': {
       cs: 'změna'
@@ -15484,6 +15619,7 @@ function init() {
       , tr: 'değişiklik'
       , he: 'שינוי'
       , hu: 'változás'
+      , dk: 'endre'
     },
     'Speech': {
       cs: 'Hlas'
@@ -15503,6 +15639,7 @@ function init() {
       , tr: 'Konuş'
       , he: 'דיבור'
       , hu: 'Beszéd'
+      , nb: 'Tale'
     },
     'Target Top': {
       cs: 'Horní cíl'
@@ -15522,6 +15659,7 @@ function init() {
       , tr: 'Hedef Üst'
       , he: 'ראש היעד'
       , hu: 'Felsó cél'
+      , nb: 'Høyt mål'
     },
     'Target Bottom': {
       cs: 'Dolní cíl'
@@ -15541,6 +15679,7 @@ function init() {
       , tr: 'Hedef Alt'
       , he: 'תחתית היעד'
       , hu: 'Alsó cél'
+      , nb: 'Lavt mål'
     },
     'Canceled': {
       cs: 'Zrušený'
@@ -15560,6 +15699,7 @@ function init() {
       , tr: 'İptal edildi'
       , he: 'מבוטל'
       , hu: 'Megszüntetett'
+      , dk: 'Avbrutt'
     },
     'Meter BG': {
       cs: 'Hodnota z glukoměru'
@@ -15579,6 +15719,7 @@ function init() {
       , tr: 'Glikometre KŞ'
       , he: 'סוכר הדם של מד'
       , hu: 'Cukorszint a mérőből'
+      , nb: 'Blodsukkermåler BS'
     },
     'predicted': {
       cs: 'přepověď'
@@ -15598,6 +15739,7 @@ function init() {
       , tr: 'tahmin'
       , he: 'חזה'
       , hu: 'előrejelzés'
+      , nb: 'predikert'
     },
     'future': {
       cs: 'budoucnost'
@@ -15617,6 +15759,7 @@ function init() {
       , tr: 'gelecek'
       , he: 'עתיד'
       , hu: 'jövő'
+      , nb: 'Fremtid'
     },
     'ago': {
       cs: 'zpět'
@@ -15635,6 +15778,7 @@ function init() {
       , tr: 'önce'
       , he: 'לפני'
       , hu: 'ezelött'
+      , nb: 'Siden'
     },
     'Last data received': {
       cs: 'Poslední data přiajata'
@@ -15654,6 +15798,7 @@ function init() {
       , tr: 'Son veri alındı'
       , he: 'הנתונים המקבל אחרונים'
       , hu: 'Utólsó adatok fogadva'
+      , nb: 'Siste data mottatt'
     },
     'Clock View': {
       cs: 'Hodiny'
@@ -15675,6 +15820,7 @@ function init() {
       ,tr: 'Saat Görünümü'
       ,he: 'צג השעון'
       ,hu: 'Idő'
+      , nb: 'Klokkevisning'
     },
     'Protein': {
       fi: 'Proteiini'
@@ -15686,6 +15832,7 @@ function init() {
       ,he: 'חלבון'
       ,nl: 'Eiwit'
       ,hu: 'Protein'
+      , nb: 'Protein'
     },
     'Fat': {
       fi: 'Rasva'
@@ -15697,8 +15844,9 @@ function init() {
       ,he: 'שמן'
       ,nl: 'Vet'
       ,hu: 'Zsír'
+      , nb: 'Fett'
     },
-    'Protein average': {
+    'Protein average' : {
       fi: 'Proteiini keskiarvo'
       ,de: 'Proteine Durchschnitt'
       ,tr: 'Protein Ortalaması'
@@ -15708,8 +15856,9 @@ function init() {
       ,he: 'חלבון ממוצע'
       ,nl: 'eiwitgemiddelde'
       ,hu: 'Protein átlag'
+      , nb: 'Gjennomsnitt protein'
     },
-    'Fat average': {
+    'Fat average' : {
       fi: 'Rasva keskiarvo'
       ,de: 'Fett Durchschnitt'
       ,tr: 'Yağ Ortalaması'
@@ -15719,8 +15868,9 @@ function init() {
       ,he: 'שמן ממוצע'
       ,nl: 'Vetgemiddelde'
       ,hu: 'Zsír átlag'
+      , nb: 'Gjennomsnitt fett'
     },
-    'Total carbs': {
+    'Total carbs' : {
       fi: 'Hiilihydraatit yhteensä'
       , de: 'Kohlenhydrate gesamt'
       ,tr: 'Toplam Karbonhidrat'
@@ -15730,6 +15880,7 @@ function init() {
       ,he: 'כל פחמימות'
       ,nl: 'Totaal koolhydraten'
       ,hu: 'Összes szénhidrát'
+      , nb: 'Totale karbohydrater'
     },
     'Total protein': {
       fi: 'Proteiini yhteensä'
@@ -15741,6 +15892,7 @@ function init() {
       ,he: 'כל חלבונים'
       ,nl: 'Totaal eiwitten'
       ,hu: 'Összes protein'
+      , nb: 'Totalt protein'
     },
     'Total fat': {
       fi: 'Rasva yhteensä'
@@ -15752,42 +15904,50 @@ function init() {
       ,he: 'כל שומנים'
       ,nl: 'Totaal vetten'
       ,hu: 'Összes zsír'
+      , nb: 'Totalt fett'
     },
     'Database Size': {
       pl: 'Rozmiar Bazy Danych'
       ,nl: 'Grootte database'
       ,de: 'Datenbankgröße'
       ,hu: 'Adatbázis mérete'
+      , nb: 'Databasestørrelse'
     },
     'Database Size near its limits!': {
       pl: 'Rozmiar bazy danych zbliża się do limitu!'
       ,nl: 'Database grootte nadert limiet!'
       ,de: 'Datenbank fast voll!'
       ,hu: 'Az adatbázis majdnem megtelt!'
+      , nb: 'Databasestørrelsen nærmer seg grensene'
     },
     'Database size is %1 MiB out of %2 MiB. Please backup and clean up database!': {
       pl: 'Baza danych zajmuje %1 MiB z dozwolonych %2 MiB. Proszę zrób kopię zapasową i oczyść bazę danych!'
       ,nl: 'Database grootte is %1 MiB van de %2 MiB. Maak een backup en verwijder oude data'
       ,de: 'Die Datenbankgröße beträgt %1 MiB von %2 MiB. Bitte sichere deine Daten und bereinige die Datenbank!'
       ,hu: 'Az adatbázis mérete %1 MiB a rendelkezésre álló %2 MiB-ból. Készítsen biztonsági másolatot!'
+      , nb: 'Databasestørrelsen er %1 MiB av %2 MiB. Vennligst ta backup og rydd i databasen!'
     },
     'Database file size': {
       pl: 'Rozmiar pliku bazy danych'
       ,nl: 'Database bestandsgrootte'
       ,de: 'Datenbank-Dateigröße'
       ,hu: 'Adatbázis file mérete'
+      , nb: 'Database filstørrelse'
+      
     },
     '%1 MiB of %2 MiB (%3%)': {
       pl: '%1 MiB z %2 MiB (%3%)'
       ,nl: '%1 MiB van de %2 MiB (%3%)'
       ,de: '%1 MiB von %2 MiB (%3%)'
       ,hu: '%1 MiB %2 MiB-ból (%3%)'
+      ,nb:  '%1 MiB av %2 MiB (%3%)'
     },
     'Data size': {
       pl: 'Rozmiar danych'
       ,nl: 'Datagrootte'
       ,de: 'Datengröße'
       ,hu: 'Adatok mérete'
+      ,nb: 'Datastørrelse'
     },
     'virtAsstDatabaseSize': {
       en: '%1 MiB. That is %2% of available database space.'
@@ -15802,7 +15962,31 @@ function init() {
       ,nl: 'Database bestandsgrootte'
       ,de: 'Datenbank-Dateigröße'
       ,hu: 'Adatbázis file méret'
-    }
+    },
+    'Carbs/Food/Time' : {
+      cs: 'Carbs/Food/Time'
+      ,he: 'Carbs/Food/Time'
+      ,nb: 'Karbo/Mat/Abs.tid'
+      ,ro: 'Carbs/Food/Time'
+      ,de: 'Carbs/Food/Time'
+      ,dk: 'Carbs/Food/Time'
+      ,es: 'Carbs/Food/Time'
+      ,fr: 'Carbs/Food/Time'
+      ,sv: 'Carbs/Food/Time'
+      ,fi: 'Carbs/Food/Time'
+      ,bg: 'Carbs/Food/Time'
+      ,hr: 'Carbs/Food/Time'
+      ,pl: 'Carbs/Food/Time'
+      ,pt: 'Carbs/Food/Time'
+      ,nl: 'Carbs/Food/Time'
+      ,ru: 'Carbs/Food/Time'
+      ,sk: 'Carbs/Food/Time'
+      ,ko: 'Carbs/Food/Time'
+      ,it: 'Carbs/Food/Time'
+      ,tr: 'Carbs/Food/Time'
+      ,zh_cn: 'Carbs/Food/Time'
+      ,hu: 'Carbs/Food/Time'
+      }
   };
 
   language.translations = translations;


### PR DESCRIPTION
* Revised translation (nb)

Revised translation after a first pass through the Norwegian (nb) translation.

* Added missing translations in Day to day report

Missing translation of 'Bolus average , 'Basal average' and 'Base basal average' from daytoday.js

* Translate (nb) missing translations in Day to day report

* Minor changes Day to day report

* Missing translation from glucosedistributon.js of 

'Out of Range RMS is calculated by squaring the distance out of range for all glucose readings for the examined period, summing them, dividing by the count and taking the square root. This metric is similar to in-range percentage but weights readings far out of range higher. Lower values are better.')

* Translate (nb) Out of range RMS....

'Out of Range RMS is calculated by squaring the distance out of range for all glucose readings for the examined period, summing them, dividing by the count and taking the square root. This metric is similar to in-range percentage but weights readings far out of range higher. Lower values are better.'

* Translate (nb) Reports: Percentile Chart

* Reports - Treatments: Added missing translation of 'Carbs/Food/Time' from 

cgm-remote-monitor\lib\report_plugins\treatments.js

* Transkate (nb) Carbs/Food/Time

* Nitpicking